### PR TITLE
fix: Update publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,13 +27,17 @@ jobs:
         cache: 'maven'
         cache-dependency-path: ./pom.xml
         server-id: ossrh  # This id should match with the id in your pom.xml or settings.xml
-        server-username: ${{ secrets.OSSRH_USERNAME }}
-        server-password: ${{ secrets.OSSRH_TOKEN }}
-        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-        gpg-passphrase: ${{ secrets.GPG_PWD }}
+        server-username: OSSRH_USERNAME # Env variable for username in deploy (Passes the environment variable name, not the value)
+        server-password: OSSRH_TOKEN # Env variable for token in deploy
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: GPG_PWD  # Env variable for GPG private key passphrase
     
     - name: Build with Maven Wrapper
       run: ./mvnw clean install
 
     - name: Deploy to Apache Maven
       run: ./mvnw deploy -P release -Dgpg.skip=false # Using the profile `release` for using the necessary dependencies
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        GPG_PWD: ${{ secrets.GPG_PWD }}

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,13 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <!-- Ensuring passphrase is provided directly from an environment variable -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
## Description

PR fixes the publish workflow with following changes:

### 1. use environment variable names instead of actual values in setup-java 
This is needed due to generation of `settings.xml` within setup-java action. We want to have the xml file in format to contain credentials as:
`<username>${env.OSSRH_USERNAME}</username>`
not as:
`<username>${env.***}</username>`

### 2. make actual values accessible only at deploy step
This ensures we import github secrets as environment variables accessible in `settings.xml` which are used by deploy step.

### 3. add configuration to `maven-gpg-plugin` to ensure passphrase is provided directly from an environment variable
This is self-describing, adding missing configuration for gpg plugin.