### PR TITLE
fix: Replace `maven-deploy-plugin` with `nexus-staging-maven-plugin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For a comprehensive list of examples, check out the [API documentation](https://
     <dependency>
       <groupId>com.buttercms</groupId>
       <artifactId>buttercmsclient</artifactId>
-      <version>1.6</version>
+      <version>1.12.0</version>
     </dependency>
 ...
 </dependencies>    
@@ -29,7 +29,7 @@ For a comprehensive list of examples, check out the [API documentation](https://
 **build.gradle**
 ```
 dependencies {
-    implementation 'com.buttercms:buttercmsclient:1.6'
+    implementation 'com.buttercms:buttercmsclient:1.12.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ For a comprehensive list of examples, check out the [API documentation](https://
 
 ### Maven
 
+<!-- {x-release-please-start-version} -->
 **pom.xml**
-```
+```xml
 <dependencies>
 ...
     <dependency>
@@ -23,15 +24,18 @@ For a comprehensive list of examples, check out the [API documentation](https://
 ...
 </dependencies>    
 ```
+<!-- {x-release-please-end} -->
 
 ### Gradle
 
+<!-- {x-release-please-start-version} -->
 **build.gradle**
 ```
 dependencies {
     implementation 'com.buttercms:buttercmsclient:1.12.0'
 }
 ```
+<!-- {x-release-please-end} -->
 
 
 ## Usage

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>buttercmsclient</artifactId>
     <!-- {x-release-please-start-version} -->
     <version>1.12.0</version>
-    <!-- x-release-please-end -->
+    <!-- {x-release-please-end} -->
 
     <name>buttercmsclient</name>
     <url>https://github.com/ButterCMS/buttercms-java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,15 @@
                 </plugin>
                 
                 <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>default-deploy</id>


### PR DESCRIPTION
### Description
- this change is required due to missing features in original plugin `maven-deploy-plugin`: promoting staging deployment to maven central repository
- `nexus-staging-maven-plugin` is meant to completely replace the `maven-deploy-plugin` as it supports same functionality and more
- with using `autoReleaseAfterClose` set to `true` you can deploy to OSSRH and release to the Central Repository in one go

More information about `nexus-staging-maven-plugin`: 
- https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md
- https://central.sonatype.org/publish/publish-maven/